### PR TITLE
Use linuxdeploy to create Appdir with libs

### DIFF
--- a/MassEffectModder/deploy_gui_linux.sh
+++ b/MassEffectModder/deploy_gui_linux.sh
@@ -19,6 +19,7 @@ Exec=MassEffectModder
 Icon=MassEffectModder
 Type=Application
 Categories=Utility;" > $bundle_path/MassEffectModder.desktop
+linuxdeploy --appdir $bundle_path
 appimagetool $bundle_path MassEffectModder.AppImage
 zip MassEffectModder-Linux-v$version.zip MassEffectModder.AppImage -0
 rm MassEffectModder.AppImage

--- a/MassEffectModder/setup-mem-linux.sh
+++ b/MassEffectModder/setup-mem-linux.sh
@@ -99,6 +99,9 @@ if [ ! -f .stamp-appimage ]; then
 wget https://github.com/AppImage/AppImageKit/releases/download/12/appimagetool-x86_64.AppImage;
 chmod +x appimagetool-x86_64.AppImage;
 mv appimagetool-x86_64.AppImage /usr/local/bin/appimagetool"
+	$CHROOT_CMD_ROOT "wget https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage;
+chmod +x linuxdeploy-x86_64.AppImage;
+mv linuxdeploy-x86_64.AppImage /usr/local/bin/linuxdeploy"
 	touch .stamp-appimage
 fi
 


### PR DESCRIPTION
Without it, we have an AppImage which does not bundle any libs,
which negates every portability advantage an .AppImage has.
E.g. we link again libxcb-util.so.0 right now, but not all
distros do provide such an old version.


