### PR TITLE
Allow ME1 to use any TFC source

### DIFF
--- a/MassEffectModder/MassEffectModder/MipMaps/MipMapsReplace.cpp
+++ b/MassEffectModder/MassEffectModder/MipMaps/MipMapsReplace.cpp
@@ -681,7 +681,7 @@ QString MipMaps::replaceTextures(QList<MapPackagesToMod> &map, QList<TextureMapE
                 if (mod.arcTexture.count() == 0)
                 {
                     archiveFile = g_GameData->MainData() + "/" + archive + ".tfc";
-                    if (g_GameData->gameType == ME1_TYPE || matched.path.contains("/DLC", Qt::CaseInsensitive))
+                    if (g_GameData->gameType == MeType::ME1_TYPE || matched.path.contains("/DLC", Qt::CaseInsensitive))
                     {
                         mod.arcTfcDLC = true;
                         QString DLCArchiveFile = g_GameData->GamePath() + DirName(matched.path) + "/" + archive + ".tfc";

--- a/MassEffectModder/MassEffectModder/MipMaps/MipMapsReplace.cpp
+++ b/MassEffectModder/MassEffectModder/MipMaps/MipMapsReplace.cpp
@@ -681,7 +681,7 @@ QString MipMaps::replaceTextures(QList<MapPackagesToMod> &map, QList<TextureMapE
                 if (mod.arcTexture.count() == 0)
                 {
                     archiveFile = g_GameData->MainData() + "/" + archive + ".tfc";
-                    if (matched.path.contains("/DLC", Qt::CaseInsensitive))
+                    if (g_GameData->gameType == ME1_TYPE || matched.path.contains("/DLC", Qt::CaseInsensitive))
                     {
                         mod.arcTfcDLC = true;
                         QString DLCArchiveFile = g_GameData->GamePath() + DirName(matched.path) + "/" + archive + ".tfc";

--- a/MassEffectModder/MassEffectModder/Texture/Texture.cpp
+++ b/MassEffectModder/MassEffectModder/Texture/Texture.cpp
@@ -299,7 +299,7 @@ const ByteBuffer Texture::getMipMapData(TextureMipMap &mipmap)
             QString filename;
             QString archive = properties->getProperty("TextureFileCacheName").getValueName();
             filename = g_GameData->MainData() + "/" + archive + ".tfc";
-            if (packagePath.contains("/DLC", Qt::CaseInsensitive))
+            if (GameData::gameType == MeType::ME1_TYPE || packagePath.contains("/DLC", Qt::CaseInsensitive))
             {
                 QString DLCArchiveFile = g_GameData->GamePath() + DirName(packagePath) + "/" + archive + ".tfc";
                 if (QFile(DLCArchiveFile).exists())


### PR DESCRIPTION
In LE1 (ME1 in MEM terms), we use an ASI called Autoload, which lets us register TFC files for use before Core.pcc loads. This allows us to not ship TFCs to the basegame and instead ship them to DLC folders, which are more self contained and easily managed. https://github.com/ME3Tweaks/LE1-ASI-Plugins/releases/tag/LE1AutoloadEnabler-v7.0

This change allows LE1 to look in DLC folders for source of TFCs, instead of just basegame.