### PR TITLE
MEMNoGui: --install-mods supports file with .mfl extension that contains list of files to install

### DIFF
--- a/MassEffectModder/MassEffectModder/CmdLine/CmdLineHelp.cpp
+++ b/MassEffectModder/MassEffectModder/CmdLine/CmdLineHelp.cpp
@@ -54,9 +54,9 @@ void DisplayHelp()
         "  --check-for-markers --gameid <game id> [--ipc]\n" \
         "     Check game data for texture markers.\n" \
         "\n" \
-        "  --install-mods --gameid <game id> --input <input dir> [--cache-amount <percent>]\n" \
+        "  --install-mods --gameid <game id> --input <input dir/.mfl file> [--cache-amount <percent>]\n" \
         "  [--repack] [--skip-markers] [--ipc] [--alot-mode] [--limit-2k] [--verify]\n" \
-        "     Install MEM mods from input directory.\n" \
+        "     Install MEM mods from input directory or MFL file list.\n" \
         "\n" \
         "  --detect-mods --gameid <game id> [--ipc]\n" \
         "     Detect known compatible mods.\n" \

--- a/MassEffectModder/MassEffectModder/CmdLine/CmdLineParams.cpp
+++ b/MassEffectModder/MassEffectModder/CmdLine/CmdLineParams.cpp
@@ -485,9 +485,9 @@ int ProcessArguments()
             errorCode = 1;
             break;
         }
-        if (!QDir(input).exists())
+        if (!QFile(input).exists() && !QDir(input).exists())
         {
-            PERROR("Input folder doesn't exist! " + input + "\n");
+            PERROR("Input folder/file doesn't exist! " + input + "\n");
             errorCode = 1;
             break;
         }

--- a/MassEffectModder/MassEffectModder/CmdLine/CmdLineTools.cpp
+++ b/MassEffectModder/MassEffectModder/CmdLine/CmdLineTools.cpp
@@ -513,7 +513,8 @@ bool CmdLineTools::InstallMods(MeType gameId, QString &inputDir,
 
     QStringList modFiles;
 
-    if (QDir(inputDir).exists()){
+    if (QDir(inputDir).exists())
+    {
         auto files = QDir(inputDir, "*.mem",
                           QDir::SortFlag::Name | QDir::SortFlag::IgnoreCase,
                           QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks).entryInfoList();
@@ -521,10 +522,13 @@ bool CmdLineTools::InstallMods(MeType gameId, QString &inputDir,
         {
             modFiles.push_back(file.absoluteFilePath());
         }
-    } else if (QFile(inputDir).exists()){
+    }
+    else if (QFile(inputDir).exists())
+    {
         QFileInfo fi(inputDir);
-        QString ext = fi.completeSuffix();  // ext = "tar.gz")
-        if (ext == "mfl") {
+        QString ext = fi.completeSuffix();
+        if (ext == "mfl")
+        {
             // MEM File List
             QFile inputFile(inputDir);
             if (inputFile.open(QIODevice::ReadOnly))
@@ -532,12 +536,12 @@ bool CmdLineTools::InstallMods(MeType gameId, QString &inputDir,
                 QTextStream in(&inputFile);
                 while (!in.atEnd())
                 {
-                   QString line = in.readLine();
-                   if (QFile(line).exists()){
+                   QString line = in.readLine().replace(QChar('\'), QChar('/''))); // Standardize path separators to /
+                   if (QFile(line).exists())
+                   {
                        modFiles.push_back(line);
                    }
                 }
-                inputFile.close();
             }
         }
     }

--- a/MassEffectModder/MassEffectModder/CmdLine/CmdLineTools.cpp
+++ b/MassEffectModder/MassEffectModder/CmdLine/CmdLineTools.cpp
@@ -511,15 +511,36 @@ bool CmdLineTools::InstallMods(MeType gameId, QString &inputDir,
     if (!Misc::CheckGamePath())
         return false;
 
-    auto files = QDir(inputDir, "*.mem",
-                      QDir::SortFlag::Name | QDir::SortFlag::IgnoreCase,
-                      QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks).entryInfoList();
     QStringList modFiles;
-    foreach (QFileInfo file, files)
-    {
-        modFiles.push_back(file.absoluteFilePath());
-    }
 
+    if (QDir(inputDir).exists()){
+        auto files = QDir(inputDir, "*.mem",
+                          QDir::SortFlag::Name | QDir::SortFlag::IgnoreCase,
+                          QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks).entryInfoList();
+        foreach (QFileInfo file, files)
+        {
+            modFiles.push_back(file.absoluteFilePath());
+        }
+    } else if (QFile(inputDir).exists()){
+        QFileInfo fi(inputDir);
+        QString ext = fi.completeSuffix();  // ext = "tar.gz")
+        if (ext == "mfl") {
+            // MEM File List
+            QFile inputFile(inputDir);
+            if (inputFile.open(QIODevice::ReadOnly))
+            {
+                QTextStream in(&inputFile);
+                while (!in.atEnd())
+                {
+                   QString line = in.readLine();
+                   if (QFile(line).exists()){
+                       modFiles.push_back(line);
+                   }
+                }
+                inputFile.close();
+            }
+        }
+    }
     return Misc::InstallMods(gameId, resources, modFiles,
                              false, alotMode, skipMarkers, verify, cacheAmount,
                              nullptr, nullptr);


### PR DESCRIPTION
I'm trying to build some more automated installation features for MassEffectModderNoGui. I have compiled and tested using a '.mfl' file with --install-mods that you pass as --input parameter. This can be used to avoid having to stage files in a specific directory (something I should have probably done for in ALOTInstaller).